### PR TITLE
strtoupper() is buggy when used for utf8 characters, thus mb_strtoupp…

### DIFF
--- a/src/LetterAvatar.php
+++ b/src/LetterAvatar.php
@@ -205,7 +205,7 @@ class LetterAvatar
     public function generate($letter, $size = null)
     {
         $this->createImage(
-            strtoupper($letter[0]),
+            function_exists('mb_strtoupper') ? mb_strtoupper($letter[0]) : strtoupper($letter[0]),
             $this->getBackgroundColor(),
             $this->getSize($size)
         );


### PR DESCRIPTION
…er should be used instead (if available)